### PR TITLE
Added recipe for lava source

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -33,3 +33,10 @@ minetest.register_craft({
     {"craftable_lava:hot_stone", "bucket:bucket_empty", "craftable_lava:hot_stone"},
     {"craftable_lava:hot_stone", "craftable_lava:hot_stone", "craftable_lava:hot_stone"}},
 })
+
+minetest.register_craft({
+    output = "default:lava_source",
+	recipe = {{"craftable_lava:hot_stone", "craftable_lava:hot_stone", "craftable_lava:hot_stone"},
+    {"craftable_lava:hot_stone", "craftable_lava:hot_stone", "craftable_lava:hot_stone"},
+    {"craftable_lava:hot_stone", "craftable_lava:hot_stone", "craftable_lava:hot_stone"}},
+})


### PR DESCRIPTION
Lava buckets get stuck in many machines that can use lava as a power source. Lava source blocks don't have this issue. This pull request enables craftable lava source blocks that can be used like lava buckets.